### PR TITLE
Fix duplicate stop network button

### DIFF
--- a/frontend/src/pages/Analytics.Olderjs
+++ b/frontend/src/pages/Analytics.Olderjs
@@ -161,20 +161,6 @@ const Analytics = (props) => {
             </button>
             </div>
 
-
-
-
-            <button
-              className="myButton"
-              onClick={() => {
-                stopNtwrkUpdate(socket);
-              }}
-            >
-              Stop Ntwrk Update
-            </button>
-
-
-
             <h2></h2>
             <input
             className="myInput"

--- a/frontend/src/pages/Analytics.js
+++ b/frontend/src/pages/Analytics.js
@@ -162,20 +162,6 @@ const Analytics = (props) => {
             </button>
             </div>
 
-
-
-
-            <button
-              className="btn btn-secondary w-100 mb-2"
-              onClick={() => {
-                stopNtwrkUpdateButton(socket);
-              }}
-            >
-              Stop Ntwrk Update
-            </button>
-
-
-
             <h2></h2>
             <input
             className="form-control mb-2"


### PR DESCRIPTION
## Summary
- remove redundant "Stop Ntwrk Update" button in `Analytics.js`
- remove same duplicate from `Analytics.Olderjs`

## Testing
- `grep -n "Stop Ntwrk Update" -n frontend/src/pages/Analytics.js`
- `grep -n "Stop Ntwrk Update" -n frontend/src/pages/Analytics.Olderjs`


------
https://chatgpt.com/codex/tasks/task_e_6867152348408325aec5c97f133590e2