### PR TITLE
Add frontend IoT topology builder

### DIFF
--- a/frontend/src/components/SimpleTopologyGraph.js
+++ b/frontend/src/components/SimpleTopologyGraph.js
@@ -1,0 +1,63 @@
+import React, { useRef, useEffect } from "react";
+import { select, forceSimulation, forceLink, forceManyBody, forceCenter } from "d3";
+
+const SimpleTopologyGraph = ({ nodes, links }) => {
+  const svgRef = useRef(null);
+
+  useEffect(() => {
+    const svg = select(svgRef.current);
+    svg.selectAll("*").remove();
+    const width = 600;
+    const height = 400;
+    svg.attr("width", width).attr("height", height);
+
+    const simulation = forceSimulation(nodes)
+      .force("link", forceLink(links).id((d) => d.name).distance(100))
+      .force("charge", forceManyBody().strength(-200))
+      .force("center", forceCenter(width / 2, height / 2));
+
+    const link = svg
+      .append("g")
+      .selectAll("line")
+      .data(links)
+      .enter()
+      .append("line")
+      .attr("stroke", "#999");
+
+    const node = svg
+      .append("g")
+      .selectAll("circle")
+      .data(nodes)
+      .enter()
+      .append("circle")
+      .attr("r", 10)
+      .attr("fill", "#007bff");
+
+    const label = svg
+      .append("g")
+      .selectAll("text")
+      .data(nodes)
+      .enter()
+      .append("text")
+      .text((d) => d.name)
+      .attr("font-size", 12)
+      .attr("dx", 12)
+      .attr("dy", ".35em");
+
+    simulation.on("tick", () => {
+      link
+        .attr("x1", (d) => d.source.x)
+        .attr("y1", (d) => d.source.y)
+        .attr("x2", (d) => d.target.x)
+        .attr("y2", (d) => d.target.y);
+
+      node.attr("cx", (d) => d.x).attr("cy", (d) => d.y);
+
+      label.attr("x", (d) => d.x).attr("y", (d) => d.y);
+    });
+  }, [nodes, links]);
+
+  return <svg ref={svgRef}></svg>;
+};
+
+export default SimpleTopologyGraph;

--- a/frontend/src/pages/Setup.js
+++ b/frontend/src/pages/Setup.js
@@ -1,10 +1,90 @@
-import React from "react";
+import React, { useState } from "react";
+import SimpleTopologyGraph from "../components/SimpleTopologyGraph";
 
 const Setup = () => {
+  const [nodes, setNodes] = useState([]);
+  const [links, setLinks] = useState([]);
+  const [nodeName, setNodeName] = useState("");
+  const [linkSource, setLinkSource] = useState("");
+  const [linkTarget, setLinkTarget] = useState("");
+
+  const addNode = () => {
+    if (!nodeName.trim()) return;
+    const id = nodes.length + 1;
+    setNodes([...nodes, { name: nodeName.trim(), status: 1, data: { id } }]);
+    setNodeName("");
+  };
+
+  const addLink = () => {
+    if (linkSource && linkTarget && linkSource !== linkTarget) {
+      setLinks([...links, { source: linkSource, target: linkTarget }]);
+      setLinkSource("");
+      setLinkTarget("");
+    }
+  };
+
+  const clearAll = () => {
+    setNodes([]);
+    setLinks([]);
+  };
+
   return (
-    <div className="text-center">
-      <h2 className="mt-5">Setup</h2>
-      <p className="lead">Configure your network and data sources here.</p>
+    <div className="container mt-4">
+      <h2 className="text-center mb-3">Setup</h2>
+      <p className="lead text-center">Build a mock IoT topology to visualize.</p>
+      <div className="row mb-4">
+        <div className="col-md-4 mb-3">
+          <h5>Add Node</h5>
+          <input
+            type="text"
+            className="form-control mb-2"
+            placeholder="Node name"
+            value={nodeName}
+            onChange={(e) => setNodeName(e.target.value)}
+          />
+          <button className="btn btn-primary w-100" onClick={addNode}>
+            Add Node
+          </button>
+        </div>
+        <div className="col-md-4 mb-3">
+          <h5>Add Link</h5>
+          <select
+            className="form-control mb-2"
+            value={linkSource}
+            onChange={(e) => setLinkSource(e.target.value)}
+          >
+            <option value="">Source node</option>
+            {nodes.map((n) => (
+              <option key={n.name} value={n.name}>
+                {n.name}
+              </option>
+            ))}
+          </select>
+          <select
+            className="form-control mb-2"
+            value={linkTarget}
+            onChange={(e) => setLinkTarget(e.target.value)}
+          >
+            <option value="">Target node</option>
+            {nodes.map((n) => (
+              <option key={n.name} value={n.name}>
+                {n.name}
+              </option>
+            ))}
+          </select>
+          <button className="btn btn-primary w-100" onClick={addLink}>
+            Add Link
+          </button>
+        </div>
+        <div className="col-md-4 mb-3 d-flex align-items-end">
+          <button className="btn btn-secondary w-100" onClick={clearAll}>
+            Clear Topology
+          </button>
+        </div>
+      </div>
+      <div className="d-flex justify-content-center">
+        <SimpleTopologyGraph nodes={nodes} links={links} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `SimpleTopologyGraph` D3 component for simple network visualization
- update Setup page with form elements to build nodes and links

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68671938f2208325b0e91e16cb56b096