### PR TITLE
Fix socket.io reconnect loop

### DIFF
--- a/backend/main.js
+++ b/backend/main.js
@@ -22,9 +22,21 @@ const LOG_PREFIX = "main: ";
 /******************************************************
  * STATIC VARIABLES: FRONTEND 
  *****************************************************/
-const app_fe=express();
-const server_fe=http.createServer(app_fe);
-const io_fe=new socketIo(server_fe, cors());
+const app_fe = express();
+// Allow cross-origin requests so the React frontend running on a different port
+// can communicate with the backend without connection resets.
+app_fe.use(cors());
+
+const server_fe = http.createServer(app_fe);
+const io_fe = new socketIo(server_fe, {
+    cors: {
+        origin: '*',
+        methods: ['GET', 'POST']
+    },
+    // Increase ping timeout values to avoid disconnect loops under heavy load
+    pingTimeout: 30000,
+    pingInterval: 10000
+});
 const io_fe_namespace=io_fe.of(CONFIG.FRONTEND_NAMESPACE);
 let own_id = null;
 let own_ip = null;

--- a/frontend/src/api/socket.js
+++ b/frontend/src/api/socket.js
@@ -1,6 +1,9 @@
 import socketio from 'socket.io-client';
 import { BE_SOCKET_URL } from '../../config/beSocketConfig.js';
 
-const socket = socketio.connect(BE_SOCKET_URL, { transports: ['websocket'] });
+// Use both polling and websocket transports to improve connection stability
+const socket = socketio(BE_SOCKET_URL, {
+  transports: ['polling', 'websocket'],
+});
 
 export default socket;


### PR DESCRIPTION
## Summary
- configure socket.io server with proper CORS options
- improve connection stability by allowing polling transport and adjusting ping timeouts

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68671ef6cb2c8325a27a6b36467e7081