### PR TITLE
Fix frontend reconnect loop

### DIFF
--- a/backend/main.js
+++ b/backend/main.js
@@ -34,8 +34,9 @@ const io_fe = new socketIo(server_fe, {
         methods: ['GET', 'POST']
     },
     // Increase ping timeout values to avoid disconnect loops under heavy load
-    pingTimeout: 30000,
-    pingInterval: 10000
+    // when the backend is busy with database operations
+    pingTimeout: 60000,
+    pingInterval: 25000
 });
 const io_fe_namespace=io_fe.of(CONFIG.FRONTEND_NAMESPACE);
 let own_id = null;

--- a/frontend/src/api/socket.js
+++ b/frontend/src/api/socket.js
@@ -4,6 +4,9 @@ import { BE_SOCKET_URL } from '../../config/beSocketConfig.js';
 // Use both polling and websocket transports to improve connection stability
 const socket = socketio(BE_SOCKET_URL, {
   transports: ['polling', 'websocket'],
+  // Match the server's ping settings so the connection isn't dropped
+  pingTimeout: 60000,
+  pingInterval: 25000,
 });
 
 export default socket;


### PR DESCRIPTION
## Summary
- increase socket pingTimeout and pingInterval for backend
- match ping settings on the frontend socket client

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686729fafe808325b1ab612efcc3284a