### PR TITLE
Fix disconnect loop when Mongo runs

### DIFF
--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,0 +1,8 @@
+{
+  "ignore": [
+    "database/data/*",
+    "database/data/**",
+    "algorithms/static_network_reconstruction/dataset/*",
+    "algorithms/static_network_reconstruction/dataset/**"
+  ]
+}


### PR DESCRIPTION
## Summary
- ignore Mongo database and dataset directories when running nodemon

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68673f94f3e08325bc87166df16dd338