### PR TITLE
Enable zoom for IoT setup graph

### DIFF
--- a/frontend/src/components/SimpleTopologyGraph.js
+++ b/frontend/src/components/SimpleTopologyGraph.js
@@ -1,5 +1,13 @@
 import React, { useRef, useEffect } from "react";
-import { select, forceSimulation, forceLink, forceManyBody, forceCenter } from "d3";
+import {
+  select,
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCenter,
+  forceCollide,
+  zoom,
+} from "d3";
 
 const SimpleTopologyGraph = ({ nodes, links }) => {
   const svgRef = useRef(null);
@@ -7,16 +15,26 @@ const SimpleTopologyGraph = ({ nodes, links }) => {
   useEffect(() => {
     const svg = select(svgRef.current);
     svg.selectAll("*").remove();
-    const width = 600;
-    const height = 400;
-    svg.attr("width", width).attr("height", height);
+    const width = 800;
+    const height = 600;
+    const container = svg
+      .attr("width", width)
+      .attr("height", height)
+      .append("g");
+
+    svg.call(
+      zoom().scaleExtent([0.5, 4]).on("zoom", (event) => {
+        container.attr("transform", event.transform);
+      })
+    );
 
     const simulation = forceSimulation(nodes)
       .force("link", forceLink(links).id((d) => d.name).distance(100))
       .force("charge", forceManyBody().strength(-200))
+      .force("collide", forceCollide(20))
       .force("center", forceCenter(width / 2, height / 2));
 
-    const link = svg
+    const link = container
       .append("g")
       .selectAll("line")
       .data(links)
@@ -24,7 +42,7 @@ const SimpleTopologyGraph = ({ nodes, links }) => {
       .append("line")
       .attr("stroke", "#999");
 
-    const node = svg
+    const node = container
       .append("g")
       .selectAll("circle")
       .data(nodes)
@@ -33,7 +51,7 @@ const SimpleTopologyGraph = ({ nodes, links }) => {
       .attr("r", 10)
       .attr("fill", "#007bff");
 
-    const label = svg
+    const label = container
       .append("g")
       .selectAll("text")
       .data(nodes)

--- a/frontend/src/pages/Setup.js
+++ b/frontend/src/pages/Setup.js
@@ -82,7 +82,10 @@ const Setup = () => {
           </button>
         </div>
       </div>
-      <div className="d-flex justify-content-center">
+      <div
+        className="d-flex justify-content-center"
+        style={{ overflow: "auto" }}
+      >
         <SimpleTopologyGraph nodes={nodes} links={links} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make the network setup graph scroll/zoom friendly
- allow the page to scroll when the graph gets large

## Testing
- `npm test --prefix frontend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6868229f9880832585ef1ac7f6e9ef2b